### PR TITLE
feat: objects api, user bulk api, deprecate prefs

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -35,6 +35,7 @@ GEM
     unicode-display_width (2.0.0)
 
 PLATFORMS
+  ruby
   x86_64-darwin-19
 
 DEPENDENCIES

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ require "knockapi"
 Knock.key = "sk_12345"
 
 # Set an entire preference set
-Knock::Preferences.set(
+Knock::Users.set_preferences(
   user_id: "jhammond",
   channel_types: { email: true, sms: false },
   workflows: {
@@ -109,7 +109,7 @@ Knock::Preferences.set(
 )
 
 # Get an entire preference set
-Knock::Preferences.get(user_id: "jhammond")
+Knock::Users.get_preferences(user_id: "jhammond")
 ```
 
 ### Getting and setting channel data

--- a/lib/knock.rb
+++ b/lib/knock.rb
@@ -25,6 +25,8 @@ module Knock
   autoload :Preferences, "knock/preferences"
   autoload :Users, "knock/users"
   autoload :Workflows, "knock/workflows"
+  autoload :BulkOperations, "knock/bulk_operations"
+  autoload :Objects, "knock/objects"
 
   # Errors
   autoload :APIError, "knock/errors"

--- a/lib/knock/bulk_operations.rb
+++ b/lib/knock/bulk_operations.rb
@@ -1,0 +1,26 @@
+require "net/http"
+require "uri"
+
+module Knock
+  # Provides convienience methods for working with bulk operations
+  module BulkOperations
+    class << self
+      include Base
+      include Client
+
+      # Retrieves the given bulk operation
+      #
+      # @param [String] id The bulk operation ID
+      #
+      # @return [Hash] The bulk operation
+      def get(id:)
+        request = get_request(
+          auth: true,
+          path: "/v1/bulk_operations/#{id}"
+        )
+
+        execute_request(request: request)
+      end
+    end
+  end
+end

--- a/lib/knock/objects.rb
+++ b/lib/knock/objects.rb
@@ -1,0 +1,125 @@
+require "net/http"
+require "uri"
+
+module Knock
+  # Provides convienience methods for working with bulk operations
+  module Objects
+    class << self
+      include Base
+      include Client
+
+      # Retrieves an Object in a collection
+      #
+      # @param [String] collection The collection the object is in
+      # @param [String] id The object id
+      #
+      # @return [Hash] The Object
+      def get(collection:, id:)
+        request = get_request(
+          auth: true,
+          path: "/v1/objects/#{collection}/#{id}"
+        )
+
+        execute_request(request: request)
+      end
+
+      # Upserts an Object in a collection
+      #
+      # @param [String] collection The collection the object is in
+      # @param [String] id The object id
+      # @param [Hash] properties The properties to set on the object
+      #
+      # @return [Hash] The Object
+      def set(collection:, id:, properties: {})
+        request = put_request(
+          auth: true,
+          path: "/v1/objects/#{collection}/#{id}",
+          body: properties
+        )
+
+        execute_request(request: request)
+      end
+
+      # Bulk upserts Objects in a collection
+      #
+      # @param [String] collection The collection the object is in
+      # @param [Array<Hash>] objects The objects to upsert
+      #
+      # @return [Hash] a BulkOperation
+      def bulk_set(collection:, objects: [])
+        request = post_request(
+          auth: true,
+          path: "/v1/objects/#{collection}/bulk/set",
+          body: {objects: objects}
+        )
+
+        execute_request(request: request)
+      end
+
+      # Deletes an Object in a collection
+      #
+      # @param [String] collection The collection the object is in
+      # @param [String] id The object id
+      #
+      # @return [nil] Nothing
+      def delete(collection:, id:)
+        request = delete_request(
+          auth: true,
+          path: "/v1/objects/#{collection}/#{id}"
+        )
+
+        execute_request(request: request)
+      end
+
+      # Bulk deletes Objects in a collection
+      #
+      # @param [String] collection The collection the object is in
+      # @param [Array<String>] object_ids The object ids to delete
+      #
+      # @return [Hash] a BulkOperation
+      def bulk_delete(collection:, object_ids: [])
+        request = post_request(
+          auth: true,
+          path: "/v1/objects/#{collection}/bulk/delete",
+          body: {object_ids: object_ids}
+        )
+
+        execute_request(request: request)
+      end
+
+      # Get object channel data for the given channel id
+      #
+      # @param [String] collection The collection the object is in
+      # @param [String] id The object id
+      # @param [String] channel_id target channel ID
+      #
+      # @return [Hash] channel data
+      def get_channel_data(collection:, id:, channel_id:)
+        request = get_request(
+          auth: true,
+          path: "/v1/objects/#{collection}/#{id}/channel_data/#{channel_id}"
+        )
+
+        execute_request(request: request)
+      end
+
+      # Upserts object channel data for the given channel id
+      #
+      # @param [String] collection The collection the object is in
+      # @param [String] id The object id
+      # @param [String] channel_id target channel ID
+      # @param [Hash] channel_data channel data
+      #
+      # @return [Hash] channel data
+      def set_channel_data(id:, channel_id:, channel_data:)
+        request = put_request(
+          auth: true,
+          path: "/v1/objects/#{collection}/#{id}/channel_data/#{channel_id}",
+          body: {data: channel_data}
+        )
+
+        execute_request(request: request)
+      end
+    end
+  end
+end

--- a/lib/knock/preferences.rb
+++ b/lib/knock/preferences.rb
@@ -2,28 +2,20 @@ require "net/http"
 require "uri"
 
 module Knock
-  # Provides convienience methods for working with preferences
+  # Provides convienience methods for working with preferences (deprecated)
   module Preferences
     class << self
       include Base
       include Client
-
-      DEFAULT_SET_ID = "default"
 
       # Returns all preference sets for the user
       #
       # @param [String] user_id The ID of the user to retrieve preferences for
       #
       # @return [Hash] The preference sets
+      # @deprecated Please use {#Knock::Users.get_all_preferences} instead
       def get_all(user_id:)
-        endpoint = "/v1/users/#{user_id}/preferences"
-
-        request = get_request(
-          auth: true,
-          path: endpoint
-        )
-
-        execute_request(request: request)
+        Knock::Users.get_all_preferences(user_id: user_id)
       end
 
       # Gets a single preference set, defaults to the 'default' set
@@ -33,15 +25,9 @@ module Knock
       # @param [String] preference_set The preference set ID (defaults to `default`)
       #
       # @return [Hash] The preference set (if it exists)
-      def get(user_id:, preference_set: DEFAULT_SET_ID)
-        endpoint = "/v1/users/#{user_id}/preferences/#{preference_set}"
-
-        request = get_request(
-          auth: true,
-          path: endpoint
-        )
-
-        execute_request(request: request)
+      # @deprecated Please use {#Knock::Users.get_preferences} instead
+      def get(user_id:, preference_set:)
+        Knock::Users.get_preferences(user_id: user_id, preference_set: preference_set)
       end
 
       # Sets multiple preferences at once for the preference set.
@@ -51,26 +37,20 @@ module Knock
       # @param [Hash] preferences The preferences hash to set
       #
       #  @return [Hash] The preference set
+      # @deprecated Please use {#Knock::Users.set_preferences} instead
       def update(
         user_id:,
-        channel_types: nil,
+        preference_set:, channel_types: nil,
         workflows: nil,
-        categories: nil,
-        preference_set: DEFAULT_SET_ID
+        categories: nil
       )
-        endpoint = "/v1/users/#{user_id}/preferences/#{preference_set}"
-
-        request = put_request(
-          auth: true,
-          path: endpoint,
-          body: {
-            channel_types: channel_types,
-            workflows: workflows,
-            categories: categories
-          }
+        Knock::Users.set_preferences(
+          user_id: user_id,
+          channel_types: channel_types,
+          workflows: workflows,
+          categories: categories,
+          preference_set: preference_set
         )
-
-        execute_request(request: request)
       end
 
       # Sets preferences for the given channel type
@@ -80,17 +60,15 @@ module Knock
       # @param [String] channel_type The channel type to set
       # @param [Bool] setting Whether the channel type is enabled or not
       #
-      #  @return [Hash] The preference set
-      def set_channel_type(user_id:, channel_type:, setting:, preference_set: DEFAULT_SET_ID)
-        endpoint = "/v1/users/#{user_id}/preferences/#{preference_set}/channel_types/#{channel_type}"
-
-        request = put_request(
-          auth: true,
-          path: endpoint,
-          body: {subscribed: setting}
+      # @return [Hash] The preference set
+      # @deprecated Please use {#Knock::Users.set_channel_type_preferences} instead
+      def set_channel_type(user_id:, channel_type:, setting:, preference_set:)
+        Knock::Users.set_channel_type_preferences(
+          user_id: user_id,
+          channel_type: channel_type,
+          setting: setting,
+          preference_set: preference_set
         )
-
-        execute_request(request: request)
       end
 
       # Sets preferences for the given workflow
@@ -101,18 +79,15 @@ module Knock
       # @param [Bool | Hash] setting Either a boolean to indicate if the type is enabled
       #  or a hash containing channel types and settings
       #
-      #  @return [Hash] The preference set
-      def set_workflow(user_id:, workflow:, setting:, preference_set: DEFAULT_SET_ID)
-        params = setting.is_a?(Hash) ? setting : {subscribed: setting}
-        endpoint = "/v1/users/#{user_id}/preferences/#{preference_set}/workflows/#{workflow}"
-
-        request = put_request(
-          auth: true,
-          path: endpoint,
-          body: params
+      # @return [Hash] The preference set
+      # @deprecated Please use {#Knock::Users.set_workflow_preferences} instead
+      def set_workflow(user_id:, workflow:, setting:, preference_set:)
+        Knock::Users.set_workflow_preferences(
+          user_id: user_id,
+          workflow: workflow,
+          setting: setting,
+          preference_set: preference_set
         )
-
-        execute_request(request: request)
       end
 
       # Sets preferences for the given category
@@ -123,18 +98,15 @@ module Knock
       # @param [Bool | Hash] setting Either a boolean to indicate if the type is enabled
       #  or a hash containing channel types and settings
       #
-      #  @return [Hash] The preference set
-      def set_category(user_id:, category:, setting:, preference_set: DEFAULT_SET_ID)
-        params = setting.is_a?(Hash) ? setting : {subscribed: setting}
-        endpoint = "/v1/users/#{user_id}/preferences/#{preference_set}/categories/#{category}"
-
-        request = put_request(
-          auth: true,
-          path: endpoint,
-          body: params
+      # @return [Hash] The preference set
+      # @deprecated Please use {#Knock::Users.set_category_preferences} instead
+      def set_category(user_id:, category:, setting:, preference_set:)
+        Knock::Users.set_category_preferences(
+          user_id: user_id,
+          category: category,
+          setting: setting,
+          preference_set: preference_set
         )
-
-        execute_request(request: request)
       end
     end
   end

--- a/lib/knock/users.rb
+++ b/lib/knock/users.rb
@@ -8,6 +8,8 @@ module Knock
       include Base
       include Client
 
+      DEFAULT_PREFERENCE_SET_ID = "default"
+
       # Identifies the user
       #
       # @param [String] id The user ID
@@ -19,6 +21,21 @@ module Knock
           auth: true,
           path: "/v1/users/#{id}",
           body: data
+        )
+
+        execute_request(request: request)
+      end
+
+      # Bulk identifies users
+      #
+      # @param [Array<Hash>] users The users to upsert
+      #
+      # @return [Hash] the BulkOperation
+      def bulk_identify(users: [])
+        request = post_request(
+          auth: true,
+          path: "/v1/users/bulk/identify",
+          body: {users: users}
         )
 
         execute_request(request: request)
@@ -52,6 +69,206 @@ module Knock
         execute_request(request: request)
       end
 
+      # Bulk deletes users
+      #
+      # @param [Array<String>] user_ids The users to delete
+      #
+      # @return [Hash] the BulkOperation
+      def bulk_delete(user_ids: [])
+        request = post_request(
+          auth: true,
+          path: "/v1/users/bulk/delete",
+          body: {user_ids: user_ids}
+        )
+
+        execute_request(request: request)
+      end
+
+      # Gets a feed for a user
+      #
+      # @param [String] id The user id
+      # @param [String] channel_id The feed id to retrieve
+      # @param [Hash] options Options to pass to the feed query
+      #
+      # @return [Hash] the feed response
+      def get_feed(id:, channel_id:, options: {})
+        request = get_request(
+          auth: true,
+          path: "/v1/users/#{id}/feeds/#{channel_id}",
+          params: options
+        )
+
+        execute_request(request: request)
+      end
+
+      ##
+      # Preferences
+      ##
+
+      # Returns all preference sets for the user
+      #
+      # @param [String] user_id The ID of the user to retrieve preferences for
+      #
+      # @return [Hash] The preference sets
+      def get_all_preferences(user_id:)
+        endpoint = "/v1/users/#{user_id}/preferences"
+
+        request = get_request(
+          auth: true,
+          path: endpoint
+        )
+
+        execute_request(request: request)
+      end
+
+      # Gets a single preference set, defaults to the 'default' set
+      # for the user given.
+      #
+      # @param [String] user_id The ID of the user to retrieve preferences for
+      # @param [String] preference_set The preference set ID (defaults to `default`)
+      #
+      # @return [Hash] The preference set (if it exists)
+      def get_preferences(user_id:, preference_set: DEFAULT_PREFERENCE_SET_ID)
+        endpoint = "/v1/users/#{user_id}/preferences/#{preference_set}"
+
+        request = get_request(
+          auth: true,
+          path: endpoint
+        )
+
+        execute_request(request: request)
+      end
+
+      # Sets multiple preferences at once for the preference set.
+      #
+      # @param [String] user_id The ID of the user to set preferences for
+      # @param [String] preference_set The preference set ID (defaults to `default`)
+      # @param [Hash] channel_types The channel_types hash to set
+      # @param [Hash] workflows The workflows hash to set
+      # @param [Hash] categories The categories hash to set
+      #
+      # @return [Hash] The preference set
+      def set_preferences(
+        user_id:,
+        channel_types: nil,
+        workflows: nil,
+        categories: nil,
+        preference_set: DEFAULT_PREFERENCE_SET_ID
+      )
+        endpoint = "/v1/users/#{user_id}/preferences/#{preference_set}"
+
+        request = put_request(
+          auth: true,
+          path: endpoint,
+          body: {
+            channel_types: channel_types,
+            workflows: workflows,
+            categories: categories
+          }
+        )
+
+        execute_request(request: request)
+      end
+
+      # Bulk sets the preference object for the users.
+      #
+      # @param [Array<String>] user_ids The ID of the user to set preferences for
+      # @param [Hash] preferences The preferences hash to set
+      # @param [String] preference_set The preference set ID (defaults to `default`)
+      #
+      # @return [Hash] BulkOperation
+      def bulk_set_preferences(
+        user_ids: [],
+        preferences: {},
+        preference_set: DEFAULT_PREFERENCE_SET_ID
+      )
+        endpoint = "/v1/users/bulk/preferences"
+
+        # Put the preference set id if it doesn't already exist
+        unless preferences.has_key("id")
+          preferences["id"] = preference_set
+        end
+
+        request = put_request(
+          auth: true,
+          path: endpoint,
+          body: {
+            user_ids: user_ids,
+            preferences: preferences
+          }
+        )
+
+        execute_request(request: request)
+      end
+
+      # Sets preferences for the given channel type
+      #
+      # @param [String] user_id The ID of the user to set preferences for
+      # @param [String] preference_set The preference set ID (defaults to `default`)
+      # @param [String] channel_type The channel type to set
+      # @param [Bool] setting Whether the channel type is enabled or not
+      #
+      # @return [Hash] The preference set
+      def set_channel_type_preferences(user_id:, channel_type:, setting:, preference_set: DEFAULT_PREFERENCE_SET_ID)
+        endpoint = "/v1/users/#{user_id}/preferences/#{preference_set}/channel_types/#{channel_type}"
+
+        request = put_request(
+          auth: true,
+          path: endpoint,
+          body: {subscribed: setting}
+        )
+
+        execute_request(request: request)
+      end
+
+      # Sets preferences for the given workflow
+      #
+      # @param [String] user_id The ID of the user to set preferences for
+      # @param [String] preference_set The preference set ID (defaults to `default`)
+      # @param [String] workflow The workflow to set preferences for
+      # @param [Bool | Hash] setting Either a boolean to indicate if the type is enabled
+      #  or a hash containing channel types and settings
+      #
+      # @return [Hash] The preference set
+      def set_workflow_preferences(user_id:, workflow:, setting:, preference_set: DEFAULT_PREFERENCE_SET_ID)
+        params = setting.is_a?(Hash) ? setting : {subscribed: setting}
+        endpoint = "/v1/users/#{user_id}/preferences/#{preference_set}/workflows/#{workflow}"
+
+        request = put_request(
+          auth: true,
+          path: endpoint,
+          body: params
+        )
+
+        execute_request(request: request)
+      end
+
+      # Sets preferences for the given category
+      #
+      # @param [String] user_id The ID of the user to set preferences for
+      # @param [String] preference_set The preference set ID (defaults to `default`)
+      # @param [String] category The category to set preferences for
+      # @param [Bool | Hash] setting Either a boolean to indicate if the type is enabled
+      #  or a hash containing channel types and settings
+      #
+      # @return [Hash] The preference set
+      def set_category_preferences(user_id:, category:, setting:, preference_set: DEFAULT_PREFERENCE_SET_ID)
+        params = setting.is_a?(Hash) ? setting : {subscribed: setting}
+        endpoint = "/v1/users/#{user_id}/preferences/#{preference_set}/categories/#{category}"
+
+        request = put_request(
+          auth: true,
+          path: endpoint,
+          body: params
+        )
+
+        execute_request(request: request)
+      end
+
+      ##
+      # Channel data
+      ##
+
       # Get user's channel data for the given channel id
       #
       # @param [String] id the user ID
@@ -71,14 +288,14 @@ module Knock
       #
       # @param [String] id the user ID
       # @param [String] channel_id target channel ID
-      # @param [String] channel_data channel data
+      # @param [Hash] channel_data channel data
       #
       # @return [Hash] channel data
       def set_channel_data(id:, channel_id:, channel_data:)
         request = put_request(
           auth: true,
           path: "/v1/users/#{id}/channel_data/#{channel_id}",
-          body: { "data": channel_data }
+          body: {data: channel_data}
         )
 
         execute_request(request: request)

--- a/lib/knock/workflows.rb
+++ b/lib/knock/workflows.rb
@@ -11,8 +11,8 @@ module Knock
       # Triggers the workflow with the given key
       #
       # @param [String] key The workflow key
-      # @param [String] actor The actor ID
-      # @param [Array<String>] recipients The recipient IDs
+      # @param [String, Hash] actor The actor identifier
+      # @param [Array<String, Hash>] recipients The recipient identifiers
       # @param [Hash] data The data to pass to the workflow
       # @param [String] cancellation_key An optional key to identify this workflow
       #  invocation for cancelling
@@ -41,7 +41,7 @@ module Knock
       #
       # @param [String] key The workflow key
       # @param [String] cancellation_key The cancellation key
-      # @param [Array<String>] recipients The recipient IDs to cancel for
+      # @param [Array<String, Hash>] recipients The recipient identifiers
       #
       # @return [Hash] - Cancellation result
       def cancel(key:, cancellation_key:, recipients: nil)


### PR DESCRIPTION
* Adds new `knock.objects` namespace and methods
* Adds new `knock.bulkOperations` namespace and method
* Deprecates `knock.preferences` in favor of `knock.users.*Preferences` methods
* Adds new `knock.users.bulk*` methods 