### PR TITLE
feat(kno-2929): add support for trigger_data filter

### DIFF
--- a/lib/knock/messages.rb
+++ b/lib/knock/messages.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'json'
 require 'net/http'
 require 'uri'
 
@@ -16,6 +17,8 @@ module Knock
       #
       # @return [Hash] Paginated list of Message records
       def list(options: {})
+        options[:trigger_data] = JSON.generate(options[:trigger_data]) if options[:trigger_data]
+
         request = get_request(
           auth: true,
           path: '/v1/messages',
@@ -60,6 +63,8 @@ module Knock
       #
       # @return [Hash] Paginated Message's activities
       def get_activities(id:, options: {})
+        options[:trigger_data] = JSON.generate(options[:trigger_data]) if options[:trigger_data]
+
         request = get_request(
           auth: true,
           path: "/v1/messages/#{id}/activities",

--- a/lib/knock/objects.rb
+++ b/lib/knock/objects.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'json'
 require 'net/http'
 require 'uri'
 
@@ -150,6 +151,8 @@ module Knock
       #
       # @return [Hash] Paginated messages response
       def get_messages(collection:, id:, options: {})
+        options[:trigger_data] = JSON.generate(options[:trigger_data]) if options[:trigger_data]
+
         request = get_request(
           auth: true,
           path: "/v1/objects/#{collection}/#{id}/messages",

--- a/lib/knock/users.rb
+++ b/lib/knock/users.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'json'
 require 'net/http'
 require 'uri'
 
@@ -95,6 +96,8 @@ module Knock
       #
       # @return [Hash] the feed response
       def get_feed(id:, channel_id:, options: {})
+        options[:trigger_data] = JSON.generate(options[:trigger_data]) if options[:trigger_data]
+
         request = get_request(
           auth: true,
           path: "/v1/users/#{id}/feeds/#{channel_id}",
@@ -345,6 +348,8 @@ module Knock
       #
       # @return [Hash] Paginated messages response
       def get_messages(id:, options: {})
+        options[:trigger_data] = JSON.generate(options[:trigger_data]) if options[:trigger_data]
+
         request = get_request(
           auth: true,
           path: "/v1/users/#{id}/messages",


### PR DESCRIPTION
Add support for the `trigger_data` param on the following endpoints:

* Messages list
* Message activities
* User messages
* Object messages
* User feed

