### PR TITLE
Allow Knock client to be used in multi-threaded Ruby applications

### DIFF
--- a/lib/knock/client.rb
+++ b/lib/knock/client.rb
@@ -6,12 +6,7 @@ module Knock
     include Kernel
 
     def client
-      return @client if defined?(@client)
-
-      @client = Net::HTTP.new(Knock::API_HOSTNAME, 443)
-      @client.use_ssl = true
-
-      @client
+      Thread.current[:knock_client] ||= build_client
     end
 
     def execute_request(request:)
@@ -120,6 +115,12 @@ module Knock
       errors.map do |error|
         "#{error['field']}: #{error['message']} (#{error['type']})"
       end.join('; ')
+    end
+
+    def build_client
+      client = Net::HTTP.new(Knock::API_HOSTNAME, 443)
+      client.use_ssl = true
+      client
     end
   end
 end


### PR DESCRIPTION
Hey!  We came across an issue where trying to use the Knock client was throwing exceptions under certain conditions and I was able to narrow it down to a threading issue.  After looking at the code, reusing the same `Net::HTTP` connection is not thread safe.  To work around this, I spiked out instantiating a new client per thread for use by that thread.

Ultimately, I'd love to have something like [Faraday](https://lostisland.github.io/faraday/) in place so the HTTP adapter is swappable, too.