### PR TITLE
feat(kno-3762): add subscriptions as recipient endpoints

### DIFF
--- a/lib/knock/client.rb
+++ b/lib/knock/client.rb
@@ -8,8 +8,9 @@ module Knock
     def client
       return @client if defined?(@client)
 
-      @client = Net::HTTP.new(Knock::API_HOSTNAME, 443)
-      @client.use_ssl = true
+      @client = Net::HTTP.new(Knock::API_HOSTNAME, 4001)
+      # @client = Net::HTTP.new(Knock::API_HOSTNAME, 443)
+      # @client.use_ssl = true
 
       @client
     end

--- a/lib/knock/objects.rb
+++ b/lib/knock/objects.rb
@@ -329,6 +329,10 @@ module Knock
       # @param [String] collection The collection the object is in
       # @param [String] id The object id
       # @param [Hash] options Options to pass to the subscriptions endpoint
+      # These include:
+      # - page_size: size of page to be returned (max: 50)
+      # - after:  after cursor for pagination
+      # - before: before cursor for pagination
       #
       # @return [Hash] Paginated subscriptions response
       def list_subscriptions(collection:, id:, options: {})
@@ -398,6 +402,10 @@ module Knock
       # @param [String] collection The collection the object is in
       # @param [String] id The object id
       # @param [Hash] options Options to pass to the subscriptions endpoint query
+      # These include:
+      # - page_size: size of page to be returned (max: 50)
+      # - after:  after cursor for pagination
+      # - before: before cursor for pagination
       #
       # @return [Hash] Paginated subscriptions response
       def get_subscriptions(collection:, id:, options: {})

--- a/lib/knock/objects.rb
+++ b/lib/knock/objects.rb
@@ -401,7 +401,7 @@ module Knock
       #
       # @return [Hash] Paginated subscriptions response
       def get_subscriptions(collection:, id:, options: {})
-        options[:mode] = "recipient"
+        options[:mode] = 'recipient'
 
         request = get_request(
           auth: true,

--- a/lib/knock/objects.rb
+++ b/lib/knock/objects.rb
@@ -392,6 +392,25 @@ module Knock
 
         execute_request(request: request)
       end
+
+      # Get object's subscriptions as recipient
+      #
+      # @param [String] collection The collection the object is in
+      # @param [String] id The object id
+      # @param [Hash] options Options to pass to the subscriptions endpoint query
+      #
+      # @return [Hash] Paginated subscriptions response
+      def get_subscriptions(collection:, id:, options: {})
+        options[:mode] = "recipient"
+
+        request = get_request(
+          auth: true,
+          path: "/v1/objects/#{collection}/#{id}/subscriptions",
+          params: options
+        )
+
+        execute_request(request: request)
+      end
     end
   end
   # rubocop:enable Metrics/ModuleLength

--- a/lib/knock/objects.rb
+++ b/lib/knock/objects.rb
@@ -29,6 +29,23 @@ module Knock
         execute_request(request: request)
       end
 
+      # Retrieves paginated objects in a collection for the provided environment
+      #
+      # @param [Hash] options Options to pass to the paginated users endpoint query.
+      # These include:
+      # - page_size: size of page to be returned (max: 50)
+      # - after:  after cursor for pagination
+      # - before: before cursor for pagination
+      def list(collection:, options: {})
+        request = get_request(
+          auth: true,
+          path: "/v1/objects/#{collection}",
+          params: options
+        )
+
+        execute_request(request: request)
+      end
+
       # Upserts an Object in a collection
       #
       # @param [String] collection The collection the object is in

--- a/lib/knock/users.rb
+++ b/lib/knock/users.rb
@@ -45,6 +45,23 @@ module Knock
         execute_request(request: request)
       end
 
+      # Retrieves paginated users for the provided environment
+      #
+      # @param [Hash] options Options to pass to the paginated users endpoint query.
+      # These include:
+      # - page_size: size of page to be returned (max: 50)
+      # - after:  after cursor for pagination
+      # - before: before cursor for pagination
+      def list(options: {})
+        request = get_request(
+          auth: true,
+          path: "/v1/users",
+          params: options
+        )
+
+        execute_request(request: request)
+      end
+
       # Retrieves the given user
       #
       # @param [String] id The user ID

--- a/lib/knock/users.rb
+++ b/lib/knock/users.rb
@@ -395,6 +395,26 @@ module Knock
 
         execute_request(request: request)
       end
+
+      ##
+      # Subscriptions
+      ##
+
+      # Get user's subscriptions
+      #
+      # @param [String] id the user ID
+      # @param [Hash] options Options to pass to the subscriptions endpoint query
+      #
+      # @return [Hash] Paginated subscriptions response
+      def get_subscriptions(id:, options: {})
+        request = get_request(
+          auth: true,
+          path: "/v1/users/#{id}/subscriptions",
+          params: options
+        )
+
+        execute_request(request: request)
+      end
     end
   end
   # rubocop:enable Metrics/ModuleLength

--- a/lib/knock/users.rb
+++ b/lib/knock/users.rb
@@ -55,7 +55,7 @@ module Knock
       def list(options: {})
         request = get_request(
           auth: true,
-          path: "/v1/users",
+          path: '/v1/users',
           params: options
         )
 


### PR DESCRIPTION
Adds missing listing endpoints for users and objects:
* GET /users
* GET /objects/:collection

Also adds:
* GET /users/:user_id/subscriptions
* GET /objects/:collection/:object_id/subscriptions?mode=recipient