### PR TITLE
fix: make actor optional on trigger call

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    knockapi (0.4.11)
+    knockapi (0.4.12)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/knock/version.rb
+++ b/lib/knock/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Knock
-  VERSION = '0.4.11'
+  VERSION = '0.4.12'
 end

--- a/lib/knock/workflows.rb
+++ b/lib/knock/workflows.rb
@@ -23,7 +23,7 @@ module Knock
       #  duplicate workflow invocations
       #
       # @return [Hash] A workflow trigger result
-      def trigger(key:, actor:, recipients:, data: {}, cancellation_key: nil, tenant: nil, idempotency_key: nil)
+      def trigger(key:, actor: nil, recipients:, data: {}, cancellation_key: nil, tenant: nil, idempotency_key: nil)
         attrs = {
           actor: actor,
           recipients: recipients,

--- a/lib/knock/workflows.rb
+++ b/lib/knock/workflows.rb
@@ -23,7 +23,7 @@ module Knock
       #  duplicate workflow invocations
       #
       # @return [Hash] A workflow trigger result
-      def trigger(key:, actor: nil, recipients:, data: {}, cancellation_key: nil, tenant: nil, idempotency_key: nil)
+      def trigger(key:, recipients:, data: {}, actor: nil, cancellation_key: nil, tenant: nil, idempotency_key: nil)
         attrs = {
           actor: actor,
           recipients: recipients,


### PR DESCRIPTION
### Description

This PR updates the `workflows.trigger` method params to make the `actor:` param optional.