### PR TITLE
Handle 429 responses as API errors

### DIFF
--- a/lib/knock/client.rb
+++ b/lib/knock/client.rb
@@ -116,6 +116,12 @@ module Knock
           http_status: http_status,
           request_id: response['x-request-id']
         )
+      when 429
+        raise APIError.new(
+          message: json['message'],
+          http_status: http_status,
+          request_id: response['x-request-id']
+        )
       end
     end
 


### PR DESCRIPTION
We noticed that 429 (rate limited) responses from the API are not handled as errors today in the client. This leads to us having to handle these manually instead of using rescues like with other errors. This PR handles 429's as a generic APIError instead.