### PR TITLE
fix: bulk set preferences api

### DIFF
--- a/lib/knock/users.rb
+++ b/lib/knock/users.rb
@@ -223,9 +223,9 @@ module Knock
         endpoint = '/v1/users/bulk/preferences'
 
         # Put the preference set id if it doesn't already exist
-        preferences['id'] = preference_set unless preferences.has_key('id')
+        preferences['id'] = preference_set unless preferences.has_key?('id')
 
-        request = put_request(
+        request = post_request(
           auth: true,
           path: endpoint,
           body: {


### PR DESCRIPTION
- Bugfix: `has_key` seems like a typo. The correct method is `has_key?`
- The api is a POST, Put seems to result in a 404