### PR TITLE
Autoload newly created errors

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    knockapi (0.6.0)
+    knockapi (0.6.1)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/knock.rb
+++ b/lib/knock.rb
@@ -49,7 +49,10 @@ module Knock
   autoload :APIError, 'knock/errors'
   autoload :AuthenticationError, 'knock/errors'
   autoload :InvalidRequestError, 'knock/errors'
+  autoload :NotFoundError, 'knock/errors'
+  autoload :RateLimitExceededError, 'knock/errors'
   autoload :TimeoutError, 'knock/errors'
+  autoload :UnprocessableEntityError, 'knock/errors'
 
   # Triggers the workflow with the given key
   #

--- a/lib/knock/version.rb
+++ b/lib/knock/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Knock
-  VERSION = '0.6.0'
+  VERSION = '0.6.1'
 end


### PR DESCRIPTION
New error classes were introduced in #25 but not autoloaded, which results in a constant uninitialised when referencing them.