### PR TITLE
fix: change MessageEmailContent `from` field from String to union type

### DIFF
--- a/lib/knockapi/models/message_get_content_response.rb
+++ b/lib/knockapi/models/message_get_content_response.rb
@@ -68,10 +68,11 @@ module Knockapi
           required :_typename, String, api_name: :__typename
 
           # @!attribute from
-          #   The sender's email address.
+          #   The sender's email address. Can be a string email address or an object
+          #   with email and name fields.
           #
-          #   @return [String]
-          required :from, String
+          #   @return [String, Knockapi::Models::MessageGetContentResponse::Data::MessageEmailContent::From]
+          required :from, union: -> { Knockapi::Models::MessageGetContentResponse::Data::MessageEmailContent::From }
 
           # @!attribute html_body
           #   The HTML body of the email message.
@@ -120,7 +121,7 @@ module Knockapi
           #
           #   @param _typename [String] The typename of the schema.
           #
-          #   @param from [String] The sender's email address.
+          #   @param from [String, Knockapi::Models::MessageGetContentResponse::Data::MessageEmailContent::From::EmailObject] The sender's email address. Can be a string or an object with email and name fields.
           #
           #   @param html_body [String] The HTML body of the email message.
           #
@@ -135,6 +136,44 @@ module Knockapi
           #   @param cc [String, nil] The CC email addresses.
           #
           #   @param reply_to [String, nil] The reply-to email address.
+
+          # The sender's email address. Can be a string email address or an object
+          # with email and name fields.
+          #
+          # @see Knockapi::Models::MessageGetContentResponse::Data::MessageEmailContent#from
+          module From
+            extend Knockapi::Internal::Type::Union
+
+            # A simple string email address.
+            variant String
+
+            # An object with email and name fields.
+            variant -> { Knockapi::Models::MessageGetContentResponse::Data::MessageEmailContent::From::EmailObject }
+
+            class EmailObject < Knockapi::Internal::Type::BaseModel
+              # @!attribute email
+              #   The sender's email address.
+              #
+              #   @return [String]
+              required :email, String
+
+              # @!attribute name
+              #   The sender's display name.
+              #
+              #   @return [String, nil]
+              optional :name, String, nil?: true
+
+              # @!method initialize(email:, name: nil)
+              #   The sender's email address as an object.
+              #
+              #   @param email [String] The sender's email address.
+              #
+              #   @param name [String, nil] The sender's display name.
+            end
+
+            # @!method self.variants
+            #   @return [Array(String, Knockapi::Models::MessageGetContentResponse::Data::MessageEmailContent::From::EmailObject)]
+          end
         end
 
         class MessageSMSContent < Knockapi::Internal::Type::BaseModel


### PR DESCRIPTION
### Problem

The Knock API returns the `from` field in email message content as an object:

```json
{ "email": "sender@example.com", "name": "Sender Name" }
```

However, MessageEmailContent declares from as required :from, String, which causes a ConversionError when the union type resolver tries to match the email content variant — the Hash value doesn't match the String type, so no variant matches and content.data fails:

Knockapi::Errors::ConversionError: Failed to parse MessageGetContentResponse.data
from Hash to MessageGetContentResponse::Data[...]. Cause: no matching variant

The only workaround is using content[:data] to bypass typed coercion entirely.

### Fix

Changes from to a union type (From) that accepts both (I wasn't sure if this was the norm or not since other types just return a plain string, eg: SMS integrations)
- A plain String (for simple email addresses)
- An EmailObject with email and name attributes (matching the actual API response)

### Tested

Verified against live Knock API responses - `content.data` now correctly returns a typed `MessageEmailContent` with from as a `From::EmailObject`.